### PR TITLE
Ccli now uses linux dialogs

### DIFF
--- a/scripts/ccli/CCli.php
+++ b/scripts/ccli/CCli.php
@@ -1,14 +1,11 @@
 <?php
 namespace scripts\ccli;
 
+use com\github\tncrazvan\catpaw\attributes\ApplicationScoped;
 use com\github\tncrazvan\catpaw\attributes\Entry;
 use com\github\tncrazvan\catpaw\attributes\Inject;
-use com\github\tncrazvan\catpaw\attributes\Singleton;
-use com\github\tncrazvan\catpaw\services\FileReaderService;
-use React\EventLoop\LoopInterface;
-use React\Stream\WritableResourceStream;
 
-#[Singleton]
+#[ApplicationScoped]
 class CCli{
 
     public function __construct(

--- a/scripts/ccli/Shell.php
+++ b/scripts/ccli/Shell.php
@@ -1,0 +1,43 @@
+<?php
+namespace scripts\ccli;
+
+class Shell{
+    protected string $args = "";
+    public static function script(string|int|float|bool ...$args):static{
+        $instance = new static();
+        foreach($args as $arg)
+            $instance->add($arg);
+        return $instance;
+    }
+
+    public function run():string|false{
+        $pipes = array (NULL, NULL, NULL);
+        // Allow user to interact with dialog
+        $in = fopen ('php://stdin', 'r');
+        $out = fopen ('php://stdout', 'w');
+        // But tell PHP to redirect stderr so we can read it
+        $p = proc_open ($this->args, array (
+            0 => $in,
+            1 => $out,
+            2 => array ('pipe', 'w')
+        ), $pipes);
+        // Wait for and read result
+        $result = stream_get_contents ($pipes[2]);
+        // Close all handles
+        fclose ($pipes[2]);
+        fclose ($out);
+        fclose ($in);
+        proc_close ($p);
+        // Return result
+        return $result;
+    }
+
+    public function reset():static{
+        $this->args = "";
+        return $this;
+    }
+    public function add(string|int|float|bool $value):static{
+        $this->args .= ' '.$value;
+        return $this;
+    }
+}

--- a/scripts/ccli/main.php
+++ b/scripts/ccli/main.php
@@ -1,12 +1,12 @@
 <?php
 namespace scripts\ccli;
 
+chdir(dirname(__FILE__).'/../..');
+require_once './vendor/autoload.php';
+
 use com\github\tncrazvan\catpaw\tools\helpers\Factory;
 use React\EventLoop\Factory as EventLoopFactory;
 use React\EventLoop\LoopInterface;
-
-chdir(dirname(__FILE__).'/../..');
-require_once './vendor/autoload.php';
 
 Factory::setObject(LoopInterface::class,EventLoopFactory::create());
 

--- a/scripts/ccli/templates/controller.txt
+++ b/scripts/ccli/templates/controller.txt
@@ -1,17 +1,16 @@
 <?php
-namespace api;
+namespace %NAMESPACE%;
 
 use com\github\tncrazvan\catpaw\attributes\http\methods\%HTTP_METHOD%;
 use com\github\tncrazvan\catpaw\attributes\http\Path;
 use com\github\tncrazvan\catpaw\attributes\Produces;
 use com\github\tncrazvan\catpaw\attributes\Singleton;
 
-#[Path("%HTTP_BASE_PATH%")]
 #[Singleton]
+#[Path("%HTTP_PATH%")]
 class %CLASS_NAME%{
 
     #[%HTTP_METHOD%]
-    #[Path("%HTTP_PATH%")]
     #[Produces("text/plain,text/html")]
     public function todo():string{
         return "todo";

--- a/src/api/SomeTest.php
+++ b/src/api/SomeTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace api;
+
+use com\github\tncrazvan\catpaw\attributes\http\methods\DELETE;
+use com\github\tncrazvan\catpaw\attributes\http\Path;
+use com\github\tncrazvan\catpaw\attributes\Produces;
+use com\github\tncrazvan\catpaw\attributes\Singleton;
+
+#[Path("/api/some-test")]
+#[Singleton]
+class SomeTest{
+
+    #[DELETE]
+    #[Produces("text/plain,text/html")]
+    public function todo():string{
+        return "todo";
+    }
+}


### PR DESCRIPTION
Ccli now uses linux dialogs, which means it will require a linux-like interactive shell to run.

In the following example the command ```composer ccli make controller``` is executed, which will assist you in creating a new http class controller.
Pick your http method name:
![image](https://user-images.githubusercontent.com/6891346/110210889-1b1bd300-7e94-11eb-908a-80afb2e5b513.png)
Then specify the path:
![image](https://user-images.githubusercontent.com/6891346/110211022-e2302e00-7e94-11eb-8cc6-ff3f1c016349.png)

And you're done.

The last piece of the ```path``` is reserved for the ```ClassName```, which will be resolved as **PascalCase**.

So in this example your controller will be located at "**src/api/SomeTest**"